### PR TITLE
Fix icon and added SVG version

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
 define(function(require, exports, module){
-    var path = module.uri.replace('config.js', '');
+    var path = module.uri.replace('config.js', '').replace(' ','%20');
     exports.path = path;
 });

--- a/images/icon.svg
+++ b/images/icon.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<rect fill="#BABABA" width="8" height="8"/>
+<rect x="16" fill="#BABABA" width="8" height="8"/>
+<rect x="8" y="8" fill="#BABABA" width="8" height="8"/>
+<rect y="16" fill="#BABABA" width="8" height="8"/>
+<rect x="16" y="16" fill="#BABABA" width="8" height="8"/>
+</svg>

--- a/services/icon.js
+++ b/services/icon.js
@@ -3,11 +3,11 @@ define(function(require, exports, module){
         icon = null;
 
     function init(){
-        var imagePath = config.path + 'images/icon.png';
+        var imagePath = config.path + 'images/icon.svg';
 
         icon = $('<a title="Lorem Pixel" id="lorempixel_icon"></a>');
 
-        icon.css('background', 'url(' + config.path + 'images/icon.png)');
+        icon.css('background', 'url(' + imagePath + ')');
         icon.appendTo($("#main-toolbar .buttons"));
     }
 


### PR DESCRIPTION
- In Mac OS X the path of brackets extensions have a white space, I added an other replace for fix it.
- Added SVG icon version for improve in retina display